### PR TITLE
read raw string so if cookie has '%', it won't cause an exception

### DIFF
--- a/solver/config.py
+++ b/solver/config.py
@@ -1,4 +1,4 @@
-from configparser import RawConfigParser
+from configparser import ConfigParser
 from pathlib import Path
 
 from .types import PathType
@@ -6,9 +6,9 @@ from .types import PathType
 
 class ConfigProxy:
 
-    def __init__(self, config: RawConfigParser):
+    def __init__(self, config: ConfigParser):
         self._config = config
-        self.cookies = self._config.get('intel_map', 'COOKIES')
+        self.cookies = self._config.get('intel_map', 'COOKIES', raw=True)
         self.lat = self._config.getfloat('intel_map', 'LAT')
         self.lng = self._config.getfloat('intel_map', 'LNG')
         self.radius = self._config.getint('intel_map', 'RADIUS')
@@ -68,6 +68,6 @@ class ConfigProxy:
 
     @classmethod
     def load_config(cls, config_path: PathType) -> 'ConfigProxy':
-        config = RawConfigParser()
+        config = ConfigParser()
         config.read(config_path, encoding='utf-8')
         return cls(config)

--- a/solver/config.py
+++ b/solver/config.py
@@ -1,4 +1,4 @@
-from configparser import ConfigParser
+from configparser import RawConfigParser
 from pathlib import Path
 
 from .types import PathType
@@ -6,7 +6,7 @@ from .types import PathType
 
 class ConfigProxy:
 
-    def __init__(self, config: ConfigParser):
+    def __init__(self, config: RawConfigParser):
         self._config = config
         self.cookies = self._config.get('intel_map', 'COOKIES')
         self.lat = self._config.getfloat('intel_map', 'LAT')
@@ -68,6 +68,6 @@ class ConfigProxy:
 
     @classmethod
     def load_config(cls, config_path: PathType) -> 'ConfigProxy':
-        config = ConfigParser()
+        config = RawConfigParser()
         config.read(config_path, encoding='utf-8')
         return cls(config)


### PR DESCRIPTION
例如 COOKIE 字串有 % 時，會出現以下 exception:

```
Traceback (most recent call last):
  File "ifssolver.py", line 193, in <module>
    main()
  File "ifssolver.py", line 150, in main
    config = ConfigProxy.load_config(config_path)
  File "/app/solver/config.py", line 73, in load_config
    return cls(config)
  File "/app/solver/config.py", line 11, in __init__
    self.cookies = self._config.get('intel_map', 'COOKIES')
  File "/usr/lib/python3.8/configparser.py", line 799, in get
    return self._interpolation.before_get(self, section, option, value,
  File "/usr/lib/python3.8/configparser.py", line 395, in before_get
    self._interpolate_some(parser, option, L, value, section, defaults, 1)
  File "/usr/lib/python3.8/configparser.py", line 442, in _interpolate_some
    raise InterpolationSyntaxError(
configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: '%
```

使用 `RawConfigParser` 可避免此問題。